### PR TITLE
Loosen requests version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.22.0
+requests>=2.22.0,==2.*
 stix2==3.0.1


### PR DESCRIPTION
requests 2.22.0 was released in May 2019. A lot of other packages now depend on higher versions causing conflicts when these need to be used in the same environment.